### PR TITLE
Feature hidellist

### DIFF
--- a/src/NHxD.Frontend.Winforms/Configuration.cs
+++ b/src/NHxD.Frontend.Winforms/Configuration.cs
@@ -715,6 +715,21 @@ namespace NHxD.Frontend.Winforms.Configuration
 
 		[JsonProperty("forceRuntimeUpdate")]
 		public bool ForceRuntimeUpdate { get; set; } = true;
+
+		[JsonProperty("colors")]
+		public ConfigTagsListColors Colors { get; set; } = new ConfigTagsListColors();
+	}
+
+	public class ConfigTagsListColors
+	{
+		[JsonProperty("whitelist")]
+		public Color Whitelist { get; set; } = Color.Blue;
+
+		[JsonProperty("blacklist")]
+		public Color Blacklist { get; set; } = Color.Red;
+
+		[JsonProperty("default")]
+		public Color Default { get; set; } = Color.FromKnownColor(KnownColor.ControlText);
 	}
 
 	public class ConfigTagsListLabelFormats

--- a/src/NHxD.Frontend.Winforms/CoverDownloader.cs
+++ b/src/NHxD.Frontend.Winforms/CoverDownloader.cs
@@ -15,11 +15,13 @@ namespace NHxD.Frontend.Winforms
 
 		public HttpClient HttpClient { get; }
 		public IPathFormatter PathFormatter { get; }
+		public MetadataKeywordLists MetadataKeywordLists { get; }
 
-		public CoverDownloader(HttpClient httpClient, IPathFormatter pathFormatter)
+		public CoverDownloader(HttpClient httpClient, IPathFormatter pathFormatter, MetadataKeywordLists metadataKeywordLists)
 		{
 			HttpClient = httpClient;
 			PathFormatter = pathFormatter;
+			MetadataKeywordLists = metadataKeywordLists;
 		}
 
 		public bool TryFindJob(int galleryId, out CoverDownloaderJob result)
@@ -59,7 +61,7 @@ namespace NHxD.Frontend.Winforms
 			searchResult.PerPage = 1;
 			searchResult.NumPages = 1;
 
-			job = new CoverDownloaderJob(HttpClient, PathFormatter, searchResult);
+			job = new CoverDownloaderJob(HttpClient, PathFormatter, MetadataKeywordLists, searchResult);
 
 			job.CoverDownloadReportProgress += Job_CoverDownloadReportProgress;
 			job.CoversDownloadStarted += Job_CoversDownloadStarted;
@@ -79,7 +81,7 @@ namespace NHxD.Frontend.Winforms
 				return;
 			}
 
-			job = new CoverDownloaderJob(HttpClient, PathFormatter, searchResult);
+			job = new CoverDownloaderJob(HttpClient, PathFormatter, MetadataKeywordLists, searchResult);
 
 			job.CoverDownloadReportProgress += Job_CoverDownloadReportProgress;
 			job.CoversDownloadStarted += Job_CoversDownloadStarted;

--- a/src/NHxD.Frontend.Winforms/DetailsBrowserView.cs
+++ b/src/NHxD.Frontend.Winforms/DetailsBrowserView.cs
@@ -84,6 +84,7 @@ namespace NHxD.Frontend.Winforms
 			MetadataKeywordLists.WhitelistChanged += Form_WhiteListChanged;
 			MetadataKeywordLists.BlacklistChanged += Form_BlackListChanged;
 			MetadataKeywordLists.IgnorelistChanged += Form_IgnoreListChanged;
+			MetadataKeywordLists.HidelistChanged += Form_HideListChanged;
 
 			DetailsModel.MetadataChanged += DetailsModel_MetadataChanged;
 
@@ -121,6 +122,15 @@ namespace NHxD.Frontend.Winforms
 				
 				CoverDownloader.Download(cachedMetadata);
 			}
+		}
+		private void Form_HideListChanged(object sender, MetadataKeywordListChangedEventArgs e)
+		{
+			if (string.IsNullOrEmpty(WebBrowser.DocumentText))
+			{
+				return;
+			}
+
+			WebBrowser.Document?.InvokeScript("__onHidelistChanged", e.ToObjectArray());
 		}
 
 		private void Form_IgnoreListChanged(object sender, MetadataKeywordListChangedEventArgs e)

--- a/src/NHxD.Frontend.Winforms/GalleryBrowserView.cs
+++ b/src/NHxD.Frontend.Winforms/GalleryBrowserView.cs
@@ -454,12 +454,13 @@ namespace NHxD.Frontend.Winforms
 					if (searchResult.Result != null)
 					{
 						SearchResult customSearchResult = new SearchResult();
-
+						
 						customSearchResult.NumPages = searchProgressArg.SearchResult.NumPages;
 						customSearchResult.PerPage = searchProgressArg.SearchResult.PerPage;
 
 						IEnumerable<Metadata> customResult;
-
+						
+						// TODO: it might be better to let the cover download job and JS to filter on their own.
 						customResult = searchProgressArg.SearchResult.Result.GetFilteredSearchResult(searchProgressArg.MetadataKeywordLists);
 
 						if (searchProgressArg.SortType != GallerySortType.None)

--- a/src/NHxD.Frontend.Winforms/MainForm.cs
+++ b/src/NHxD.Frontend.Winforms/MainForm.cs
@@ -147,8 +147,8 @@ namespace NHxD.Frontend.Winforms
 
 			backgroundTaskWorker = new BackgroundTaskWorker() { IdleWaitTime = Settings.BackgroundWorkers.BackgroundTaskWorker.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.BackgroundTaskWorker.MaxConcurrentJobCount };
 			pageDownloader = new PageDownloader(staticHttpClient.Client, pathFormatter, searchResultCache, cacheFileSystem) { IdleWaitTime = Settings.BackgroundWorkers.PageDownloader.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.PageDownloader.MaxConcurrentJobCount };
-			coverDownloader = new CoverDownloader(staticHttpClient.Client, pathFormatter) { IdleWaitTime = Settings.BackgroundWorkers.CoverDownloader.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.CoverDownloader.MaxConcurrentJobCount };
-			coverLoader = new CoverDownloader(staticHttpClient.Client, pathFormatter) { IdleWaitTime = Settings.BackgroundWorkers.CoverLoader.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.CoverLoader.MaxConcurrentJobCount };
+			coverDownloader = new CoverDownloader(staticHttpClient.Client, pathFormatter, metadataKeywordLists) { IdleWaitTime = Settings.BackgroundWorkers.CoverDownloader.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.CoverDownloader.MaxConcurrentJobCount };
+			coverLoader = new CoverDownloader(staticHttpClient.Client, pathFormatter, metadataKeywordLists) { IdleWaitTime = Settings.BackgroundWorkers.CoverLoader.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.CoverLoader.MaxConcurrentJobCount };
 			galleryDownloader = new GalleryDownloader(staticHttpClient.Client, pathFormatter, searchResultCache) { IdleWaitTime = Settings.BackgroundWorkers.GalleryDownloader.IdleWaitTime, MaxConcurrentJobCount = Settings.BackgroundWorkers.GalleryDownloader.MaxConcurrentJobCount };
 
 			detailsTabControl = new TabControlEx();

--- a/src/NHxD.Frontend.Winforms/Properties/AssemblyInfo.cs
+++ b/src/NHxD.Frontend.Winforms/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.2")]
 
 [assembly: CLSCompliant(true)]
 

--- a/src/NHxD.Frontend.Winforms/TagsTreeView.cs
+++ b/src/NHxD.Frontend.Winforms/TagsTreeView.cs
@@ -274,15 +274,15 @@ namespace NHxD.Frontend.Winforms
 
 		private void AddItem(TreeNode categoryNode, TagInfo tag)
 		{
-			bool isInWhiteList = MetadataKeywordLists.Whitelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
-			bool isInBlackList = MetadataKeywordLists.Blacklist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
-			bool isInIgnoreList = MetadataKeywordLists.Ignorelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
+			bool isInWhitelist = MetadataKeywordLists.Whitelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
+			bool isInBlacklist = MetadataKeywordLists.Blacklist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
+			bool isInIgnorelist = MetadataKeywordLists.Ignorelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
+			bool isInHidelist = MetadataKeywordLists.Hidelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
 
-			//string tagLabel = tag.Name;
 			string tagLabel = TagTextFormatter.Format(tag, TagsListSettings.LabelFormats.Tag);
 			TreeNode contentNode = new TreeNode(tagLabel);
 
-			if (isInIgnoreList)
+			if (isInIgnorelist)
 			{
 				if (strikethroughFont == null)
 				{
@@ -292,13 +292,17 @@ namespace NHxD.Frontend.Winforms
 				contentNode.NodeFont = strikethroughFont;
 			}
 
-			if (isInWhiteList)
+			if (isInWhitelist)
 			{
-				contentNode.ForeColor = Color.Blue;
+				contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Whitelist, isInHidelist);
 			}
-			else if (isInBlackList)
+			else if (isInBlacklist)
 			{
-				contentNode.ForeColor = Color.Red;
+				contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Blacklist, isInHidelist);
+			}
+			else
+			{
+				contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Default, isInHidelist);
 			}
 
 			contentNode.Tag = tag;
@@ -331,39 +335,88 @@ namespace NHxD.Frontend.Winforms
 			bool isInWhitelist = MetadataKeywordLists.Whitelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
 			bool isInBlacklist = MetadataKeywordLists.Blacklist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
 			bool isInIgnorelist = MetadataKeywordLists.Ignorelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
+			bool isInHidelist = MetadataKeywordLists.Hidelist[tag.Type].Any(x => x.Equals(tag.Name, StringComparison.OrdinalIgnoreCase));
 
 			if (isInWhitelist)
 			{
-				contentNode.ForeColor = Color.Blue;
-				contextMenu.MenuItems.Add(new MenuItem("&Remove from whitelist", (sender2, e2) => { contentNode.ForeColor = Color.FromKnownColor(KnownColor.ControlText); MetadataKeywordLists.Whitelist.Remove(tag); }) { Name = "whitelist_remove" });
+				contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Whitelist, isInHidelist);
+				contextMenu.MenuItems.Add(new MenuItem("&Remove from whitelist", (sender2, e2) =>
+				{
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Default, isInHidelist);
+					MetadataKeywordLists.Whitelist.Remove(tag);
+				}) { Name = "whitelist_remove" });
 			}
 			else if (isInBlacklist)
 			{
-				contentNode.ForeColor = Color.Red;
-				contextMenu.MenuItems.Add(new MenuItem("&Remove from blacklist", (sender2, e2) => { contentNode.ForeColor = Color.FromKnownColor(KnownColor.ControlText); MetadataKeywordLists.Blacklist.Remove(tag); }) { Name = "blacklist_remove" });
+				contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Blacklist, isInHidelist);
+				contextMenu.MenuItems.Add(new MenuItem("&Remove from blacklist", (sender2, e2) =>
+				{
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Default, isInHidelist);
+					MetadataKeywordLists.Blacklist.Remove(tag);
+				}) { Name = "blacklist_remove" });
 			}
 
 			if (isInIgnorelist)
 			{
 				contentNode.NodeFont = strikethroughFont;
-				contextMenu.MenuItems.Add(new MenuItem("&Remove from ignorelist", (sender2, e2) => { contentNode.NodeFont = null; MetadataKeywordLists.Ignorelist.Remove(tag); }) { Name = "ignorelist_remove" });
+				contextMenu.MenuItems.Add(new MenuItem("&Remove from ignorelist", (sender2, e2) =>
+				{
+					contentNode.NodeFont = null;
+					MetadataKeywordLists.Ignorelist.Remove(tag);
+				}) { Name = "ignorelist_remove" });
+			}
+
+			if (isInHidelist)
+			{
+				contextMenu.MenuItems.Add(new MenuItem("&Remove from hidelist", (sender2, e2) =>
+				{
+					Color hidelistColor = GetHidelistColor(isInWhitelist, isInBlacklist);
+
+					contentNode.ForeColor = GetTreeNodeForeColor(hidelistColor, false);
+					MetadataKeywordLists.Hidelist.Remove(tag);
+				}) { Name = "hidelist_remove" });
 			}
 
 			if (!isInWhitelist && !isInBlacklist)
 			{
-				contextMenu.MenuItems.Add(new MenuItem("&Add to whitelist", (sender2, e2) => { contentNode.ForeColor = Color.Blue; MetadataKeywordLists.Whitelist.Add(tag); }) { Name = "whitelist_add" });
-				contextMenu.MenuItems.Add(new MenuItem("&Add to blacklist", (sender2, e2) => { contentNode.ForeColor = Color.Red; MetadataKeywordLists.Blacklist.Add(tag); }) { Name = "blacklist_add" });
+				contextMenu.MenuItems.Add(new MenuItem("&Add to whitelist", (sender2, e2) =>
+				{
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Whitelist, isInHidelist);
+					MetadataKeywordLists.Whitelist.Add(tag);
+				}) { Name = "whitelist_add" });
+
+				contextMenu.MenuItems.Add(new MenuItem("&Add to blacklist", (sender2, e2) =>
+				{
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Blacklist, isInHidelist);
+					MetadataKeywordLists.Blacklist.Add(tag);
+				}) { Name = "blacklist_add" });
 			}
 
 			if (!isInIgnorelist)
 			{
-				contextMenu.MenuItems.Add(new MenuItem("&Add to ignorelist", (sender2, e2) => { contentNode.NodeFont = strikethroughFont; MetadataKeywordLists.Ignorelist.Add(tag); }) { Name = "ignorelist_add" });
+				contextMenu.MenuItems.Add(new MenuItem("&Add to ignorelist", (sender2, e2) =>
+				{
+					contentNode.NodeFont = strikethroughFont;
+					MetadataKeywordLists.Ignorelist.Add(tag);
+				}) { Name = "ignorelist_add" });
+			}
+
+			if (!isInHidelist)
+			{
+				contextMenu.MenuItems.Add(new MenuItem("&Add to hidelist", (sender2, e2) =>
+				{
+					Color hidelistColor = GetHidelistColor(isInWhitelist, isInBlacklist);
+
+					contentNode.ForeColor = GetTreeNodeForeColor(hidelistColor, true);
+					MetadataKeywordLists.Hidelist.Add(tag);
+				}) { Name = "hidelist_add" });
 			}
 
 			if (contextMenu.MenuItems.Count > 0)
 			{
 				contextMenu.MenuItems.Add("-");
 			}
+
 			contextMenu.MenuItems.Add(new MenuItem("&Add bookmark", (sender2, e2) => { BookmarkPromptUtility.ShowAddTaggedBookmarkPrompt(tag.Id, 1); }) { Name = "search_definition" });
 
 			if (tag.Type == TagType.Tag)
@@ -372,8 +425,29 @@ namespace NHxD.Frontend.Winforms
 				{
 					contextMenu.MenuItems.Add("-");
 				}
+
 				contextMenu.MenuItems.Add(new MenuItem("&Search for definition", (sender2, e2) => { TagDefinition tagDefinition = new TagDefinition(tag.Name, HttpClient); tagDefinition.Search(); }) { Name = "search_definition" });
 			}
+		}
+
+		private Color GetHidelistColor(bool isInWhitelist, bool isInBlacklist)
+		{
+			Color restoredColor;
+
+			if (isInWhitelist)
+			{
+				restoredColor = TagsListSettings.Colors.Whitelist;
+			}
+			else if (isInBlacklist)
+			{
+				restoredColor = TagsListSettings.Colors.Blacklist;
+			}
+			else
+			{
+				restoredColor = TagsListSettings.Colors.Default;
+			}
+
+			return restoredColor;
 		}
 
 		public TreeNode GetTagTreeNode(string categoryName, string tagName, int tagId)
@@ -517,28 +591,32 @@ namespace NHxD.Frontend.Winforms
 
 		private void Whitelist_Changed(object sender, MetadataKeywordListChangedEventArgs e)
 		{
+			bool isInHidelist = MetadataKeywordLists.Hidelist[e.TagType].Any(x => x.Equals(e.TagName, StringComparison.OrdinalIgnoreCase));
+
 			MetadataKeywordLists_ListChanged(sender, e,
 				(contentNode) =>
 				{
-					contentNode.ForeColor = Color.Blue;
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Whitelist, isInHidelist);
 				},
 				(contentNode) =>
 				{
-					contentNode.ForeColor = Color.FromKnownColor(KnownColor.ControlText);
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Default, isInHidelist);
 				}
 			);
 		}
 
 		private void Blacklist_Changed(object sender, MetadataKeywordListChangedEventArgs e)
 		{
+			bool isInHidelist = MetadataKeywordLists.Hidelist[e.TagType].Any(x => x.Equals(e.TagName, StringComparison.OrdinalIgnoreCase));
+
 			MetadataKeywordLists_ListChanged(sender, e,
 				(contentNode) =>
 				{
-					contentNode.ForeColor = Color.Red;
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Blacklist, isInHidelist);
 				},
 				(contentNode) =>
 				{
-					contentNode.ForeColor = Color.FromKnownColor(KnownColor.ControlText);
+					contentNode.ForeColor = GetTreeNodeForeColor(TagsListSettings.Colors.Default, isInHidelist);
 				}
 			);
 		}
@@ -559,19 +637,38 @@ namespace NHxD.Frontend.Winforms
 
 		private void Hidelist_Changed(object sender, MetadataKeywordListChangedEventArgs e)
 		{
-			// TODO: finish implementing hidelist.
-			/*
-			MainForm_ListChanged(sender, e,
+			bool isInWhitelist = MetadataKeywordLists.Whitelist[e.TagType].Any(x => x.Equals(e.TagName, StringComparison.OrdinalIgnoreCase));
+			bool isInBlacklist = MetadataKeywordLists.Blacklist[e.TagType].Any(x => x.Equals(e.TagName, StringComparison.OrdinalIgnoreCase));
+
+			MetadataKeywordLists_ListChanged(sender, e,
 				(contentNode) =>
 				{
-					contentNode.NodeFont = tagsTreeView.StrikethroughFont;
+					contentNode.ForeColor = GetTreeNodeForeColor(GetHidelistColor(isInWhitelist, isInBlacklist), true);
 				},
 				(contentNode) =>
 				{
-					contentNode.NodeFont = null;
+					contentNode.ForeColor = GetTreeNodeForeColor(GetHidelistColor(isInWhitelist, isInBlacklist), false);
 				}
 			);
-			*/
+		}
+
+		private Color GetTreeNodeForeColor(Color baseColor, bool isInHidelist)
+		{
+			if (isInHidelist)
+			{
+				if (baseColor.GetBrightness() <= 0.1f)
+				{
+					return Color.Gray;
+				}
+				else
+				{
+					return ControlPaint.Light(baseColor, 25.0f);
+				}
+			}
+			else
+			{
+				return baseColor;
+			}
 		}
 
 		// TODO: handle the case of clicking inside the node (but outside the label) then releasing inside the label

--- a/src/NHxD.Frontend.Winforms/assets/scripts/details.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/details.js
@@ -41,7 +41,11 @@ function setCover(metadata, coverPath, error)
 		{
 			img.onerror = null
 			img.src = "assets/images/cover/200x200/missing.png"
-			img.title = error
+
+			if (error !== "SKIP")
+			{
+				img.title = error
+			}
 		}
 		else
 		{

--- a/src/NHxD.Frontend.Winforms/assets/scripts/details.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/details.js
@@ -193,6 +193,14 @@ function __onIgnorelistChanged(eventType, fieldType, fieldValue)
 	highlightTitles()
 }
 
+function __onHidelistChanged(eventType, fieldType, fieldValue)
+{
+	MetadataKeywordList.synchronizeList(eventType, fieldType, fieldValue, hidelist)
+	applyCustomTagStyle(fieldType, -1, fieldValue)
+	highlightTitles()
+}
+
+
 function addTagToWhitelist()
 {
 	var tagType = tagContextMenu.target._tag.type
@@ -226,6 +234,17 @@ function addTagToIgnorelist()
 	tagContextMenu.close()
 }
 
+function addTagToHidelist()
+{
+	var tagType = tagContextMenu.target._tag.type
+	var tagName = tagContextMenu.target._tag.name
+	var tagId = tagContextMenu.target._tag.id
+
+	window.external.MetadataKeywordLists.Hidelist.AddTag(tagType, tagName, tagId)
+
+	tagContextMenu.close()
+}
+
 function removeTagFromWhitelist()
 {
 	var tagType = tagContextMenu.target._tag.type
@@ -255,6 +274,17 @@ function removeTagFromIgnorelist()
 	var tagId = tagContextMenu.target._tag.id
 
 	window.external.MetadataKeywordLists.Ignorelist.RemoveTag(tagType, tagName, tagId)
+
+	tagContextMenu.close()
+}
+
+function removeTagFromHidelist()
+{
+	var tagType = tagContextMenu.target._tag.type
+	var tagName = tagContextMenu.target._tag.name
+	var tagId = tagContextMenu.target._tag.id
+
+	window.external.MetadataKeywordLists.Hidelist.RemoveTag(tagType, tagName, tagId)
 
 	tagContextMenu.close()
 }
@@ -330,13 +360,16 @@ function TagContextMenu_OnBeforeOpenContextMenu(target)
 	var isInWhitelist = whitelist.tags[tagType].indexOf(tagName) !== -1
 	var isInBlacklist = blacklist.tags[tagType].indexOf(tagName) !== -1
 	var isInIgnorelist = ignorelist.tags[tagType].indexOf(tagName) !== -1
+	var isInHidelist = hidelist.tags[tagType].indexOf(tagName) !== -1
 
 	document.getElementById("menu-command-remove-whitelist").addOrRemoveClass("display-none", !isInWhitelist)
 	document.getElementById("menu-command-remove-blacklist").addOrRemoveClass("display-none", !(isInBlacklist))
 	document.getElementById("menu-command-remove-ignorelist").addOrRemoveClass("display-none", !(isInIgnorelist))
+	document.getElementById("menu-command-remove-hidelist").addOrRemoveClass("display-none", !(isInHidelist))
 	document.getElementById("menu-command-add-whitelist").addOrRemoveClass("display-none", !(!isInWhitelist && !isInBlacklist))
 	document.getElementById("menu-command-add-blacklist").addOrRemoveClass("display-none", !(!isInBlacklist && !isInWhitelist))
 	document.getElementById("menu-command-add-ignorelist").addOrRemoveClass("display-none", !(!isInIgnorelist))
+	document.getElementById("menu-command-add-hidelist").addOrRemoveClass("display-none", !(!isInHidelist))
 	document.getElementById("menu-command-add-tag-bookmark").addOrRemoveClass("display-none", false)
 	document.getElementById("menu-command-show-definition").addOrRemoveClass("display-none", !(tagType === "tag"))
 
@@ -431,10 +464,12 @@ function applyCustomTagStyle(tagType, tagId, tagName, button)
 	var isInWhitelist = whitelist.tags[tagType].indexOf(tagName) !== -1
 	var isInBlacklist = blacklist.tags[tagType].indexOf(tagName) !== -1
 	var isInIgnorelist = ignorelist.tags[tagType].indexOf(tagName) !== -1
+	var isInHidelist = hidelist.tags[tagType].indexOf(tagName) !== -1
 
 	button.addOrRemoveClass("tag-whitelist", isInWhitelist)
 	button.addOrRemoveClass("tag-blacklist", isInBlacklist)
 	button.addOrRemoveClass("tag-ignorelist", isInIgnorelist)
+	button.addOrRemoveClass("tag-hidelist", isInHidelist)
 }
 
 function initCover()

--- a/src/NHxD.Frontend.Winforms/assets/scripts/download.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/download.js
@@ -238,6 +238,12 @@ function __onIgnorelistChanged(eventType, fieldType, fieldValue)
 	highlightTitles()
 }
 
+function __onHidelistChanged(eventType, fieldType, fieldValue)
+{
+	MetadataKeywordList.synchronizeList(eventType, fieldType, fieldValue, hidelist)
+	highlightTitles()
+}
+
 //
 // UI
 //

--- a/src/NHxD.Frontend.Winforms/assets/scripts/lib/metadata-filter.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/lib/metadata-filter.js
@@ -15,6 +15,12 @@
 	MetadataFilter.statementSeparatorRegex = new RegExp("[^" + MetadataFilter.statementSeparators.join('') + "]+|" + MetadataFilter.statementSeparators.join('|'), "g")
 	MetadataFilter.conditionSeparatorRegex = /([^|&]+|\||&+)/g
 
+	// lazy. used mainly for quick debugging.
+	MetadataFilter.whitelist = whitelist
+	MetadataFilter.blacklist = blacklist
+	MetadataFilter.ignorelist = ignorelist
+	MetadataFilter.hidelist = hidelist
+
 	MetadataFilter.tagNames =
 	[
 		"tag",
@@ -381,6 +387,30 @@
 			var compare = this.parseNumberCondition(condition)
 
 			result = compare(metadata.media_id.toString())
+		}
+		else if (propertyFilter === "whitelist" && typeof MetadataKeywordList !== "undefined")
+		{
+			var compare = this.parseBooleanCondition(condition)
+
+			result = compare(MetadataKeywordList.isInList(this.whitelist, metadata))
+		}
+		else if (propertyFilter === "blacklist" && typeof MetadataKeywordList !== "undefined")
+		{
+			var compare = this.parseBooleanCondition(condition)
+
+			result = compare(MetadataKeywordList.isInList(this.blacklist, metadata))
+		}
+		else if (propertyFilter === "ignorelist" && typeof MetadataKeywordList !== "undefined")
+		{
+			var compare = this.parseBooleanCondition(condition)
+
+			result = compare(MetadataKeywordList.isInList(this.ignorelist, metadata))
+		}
+		else if (propertyFilter === "hidelist" && typeof MetadataKeywordList !== "undefined")
+		{
+			var compare = this.parseBooleanCondition(condition)
+
+			result = compare(MetadataKeywordList.isInList(this.hidelist, metadata))
 		}
 		else if (this.titlePartNames.any(function(x) { return x === propertyFilter }))
 		{

--- a/src/NHxD.Frontend.Winforms/assets/scripts/lib/metadata-keyword-list.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/lib/metadata-keyword-list.js
@@ -30,6 +30,11 @@
 		{
 			button.addClass("tag-ignorelist")
 		}
+
+		if (this.isInList(hidelist, metadata))
+		{
+			button.addClass("tag-hidelist")
+		}
 	}
 
 	MetadataKeywordList.applyToSearchResult = function(searchResult, elementSelector)

--- a/src/NHxD.Frontend.Winforms/assets/scripts/lib/title-html-formatter.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/lib/title-html-formatter.js
@@ -7,6 +7,7 @@
 	titleFormatter.whitelistRegex = null
 	titleFormatter.blacklistRegex = null
 	titleFormatter.ignorelistRegex = null
+	titleFormatter.hidelistRegex = null
 	// with "japanese | english" title:
 	//^(\(([^)]+)\)){0,1}\s*(\[([^\]]+)\]){0,1}\s*([^([$|]*)(?:\| ){0,1}\s*([^([$]*)\s*(\(([^)]+)\)){0,1}\s*(\[([^\]]+)\]){0,1}\s*((?:\[|{)([^\]}]+)(?:\]|})){0,1}\s*(\[([^\]]+)\]){0,1}
 
@@ -23,6 +24,11 @@
 	document.addEventListener("ignorelistchanged", function()
 	{
 		titleFormatter.ignorelistRegex = null
+	})
+
+	document.addEventListener("hidelistchanged", function()
+	{
+		titleFormatter.hidelistRegex = null
 	})
 
 	titleFormatter.format = function(title, name)

--- a/src/NHxD.Frontend.Winforms/assets/scripts/library-covergrid.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/library-covergrid.js
@@ -268,6 +268,11 @@ function __onIgnorelistChanged(eventType, fieldType, fieldValue)
 	updateBlurs()
 }
 
+function __onHidelistChanged(eventType, fieldType, fieldValue)
+{
+	MetadataKeywordList.synchronizeList(eventType, fieldType, fieldValue, hidelist)
+}
+
 //
 // Initialization
 //

--- a/src/NHxD.Frontend.Winforms/assets/scripts/search-covergrid.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/search-covergrid.js
@@ -270,6 +270,12 @@ function __onIgnorelistChanged(eventType, fieldType, fieldValue)
 	updateBlurs()
 }
 
+function __onHidelistChanged(eventType, fieldType, fieldValue)
+{
+	MetadataKeywordList.synchronizeList(eventType, fieldType, fieldValue, hidelist)
+	updateHidden()
+}
+
 //
 // Misc.
 //
@@ -322,6 +328,46 @@ function updateBlurs()
 			button.removeClass("tag-ignorelist")
 		}
 	}
+}
+
+function updateHidden()
+{
+	//var dirtyIndices = []
+
+	for (var i = 0, len = searchResult.result.length; i < len; ++i)
+	{
+		var metadata = searchResult.result[i]
+		var button = document.getElementById("search-result-item-" + metadata.id)
+
+		if (button)
+		{
+			if (MetadataKeywordList.isInList(hidelist, metadata))
+			{
+				button.addClass("display-none")
+				//dirtyIndices.push(i)
+			}
+			else
+			{
+				button.removeClass("display-none")
+			}
+		}
+		// TODO: restore item. we could clone any other item and replace the values accordingly, but is it really worth all the trouble?
+		/*else
+		{
+			if (MetadataKeywordList.isInList(hidelist, metadata))
+			{
+			}
+		}
+		*/
+	}
+
+	/*for (var i = 0, len = dirtyIndices.length; i > len; --i)
+	{
+		// TODO: store the item somewhere, so that it can be restored later, if needed.
+		unusedResult.push(searchResult.result[dirtyIndices[i - 1]])
+
+		searchResult.result.slice(dirtyIndices[i - 1], dirtyIndices[i - 1] + 1)
+	}*/
 }
 
 //

--- a/src/NHxD.Frontend.Winforms/assets/scripts/search-covergrid.js
+++ b/src/NHxD.Frontend.Winforms/assets/scripts/search-covergrid.js
@@ -62,7 +62,11 @@ function setCover(metadata, coverPath, error)
 		{
 			img.onerror = null
 			img.src = "assets/images/cover/200x200/missing.png"
-			img.title = error
+
+			if (error !== "SKIP")
+			{
+				img.title = error
+			}
 		}
 		else
 		{
@@ -666,6 +670,7 @@ function initCache()
 	window.external.Browsers.Gallery.ApplyFilter()
 	highlightMetadataKeywordLists()
 	highlightTitles()
+	updateHidden()
 	initContextMenus()
 	initCovers()
 	initCache()

--- a/src/NHxD.Frontend.Winforms/assets/styles/details.css
+++ b/src/NHxD.Frontend.Winforms/assets/styles/details.css
@@ -198,6 +198,11 @@ table
 	text-decoration: line-through;
 }
 
+.tag-hidelist
+{
+	opacity: 0.5;
+}
+
 .tag-type span
 {
 	padding-right: 10px;

--- a/src/NHxD.Frontend.Winforms/assets/styles/search-covergrid.css
+++ b/src/NHxD.Frontend.Winforms/assets/styles/search-covergrid.css
@@ -158,6 +158,10 @@ span.tag-ignorelist
 {
 }
 
+span.tag-hidelist
+{
+}
+
 #tag-container-12227:before/*english*/
 {
 	content: url(../images/shared/country-flags/23x17/GB.png);

--- a/src/NHxD.Frontend.Winforms/assets/templates/details.html
+++ b/src/NHxD.Frontend.Winforms/assets/templates/details.html
@@ -23,11 +23,12 @@
 			}
 		</style>
 		<script type="text/javascript">
-		    var metadata = {Metadata}
-		    var whitelist = {MetadataKeywordList.Whitelist}
-		    var blacklist = {MetadataKeywordList.Blacklist}
-		    var ignorelist = {MetadataKeywordList.Ignorelist}
-		    var uploadDate = metadata.upload_date
+			var metadata = {Metadata}
+			var whitelist = {MetadataKeywordList.Whitelist}
+			var blacklist = {MetadataKeywordList.Blacklist}
+			var ignorelist = {MetadataKeywordList.Ignorelist}
+			var hidelist = {MetadataKeywordList.Hidelist}
+			var uploadDate = metadata.upload_date
 
 			function markCoverAsLoaded(img)
 			{
@@ -119,9 +120,11 @@
 			<button id="menu-command-remove-whitelist" class="menu-command" onclick="removeTagFromWhitelist()"><span class="icon"></span>Remove from whitelist</button>
 			<button id="menu-command-remove-blacklist" class="menu-command" onclick="removeTagFromBlacklist()"><span class="icon"></span>Remove from blacklist</button>
 			<button id="menu-command-remove-ignorelist" class="menu-command" onclick="removeTagFromIgnorelist()"><span class="icon"></span>Remove from ignorelist</button>
+			<button id="menu-command-remove-hidelist" class="menu-command" onclick="removeTagFromHidelist()"><span class="icon"></span>Remove from hidelist</button>
 			<button id="menu-command-add-whitelist" class="menu-command" onclick="addTagToWhitelist()"><span class="icon"></span>Add to whitelist</button>
 			<button id="menu-command-add-blacklist" class="menu-command" onclick="addTagToBlacklist()"><span class="icon"></span>Add to blacklist</button>
 			<button id="menu-command-add-ignorelist" class="menu-command" onclick="addTagToIgnorelist()"><span class="icon"></span>Add to ignorelist</button>
+			<button id="menu-command-add-hidelist" class="menu-command" onclick="addTagToHidelist()"><span class="icon"></span>Add to hidelist</button>
 			<hr />
 			<button id="menu-command-show-definition" class="menu-command" onclick="showTagDefinition()"><span class="icon"></span>Search for definition</button>
 		</div>

--- a/src/NHxD.Frontend.Winforms/assets/templates/download.html
+++ b/src/NHxD.Frontend.Winforms/assets/templates/download.html
@@ -27,6 +27,7 @@
 			var whitelist = {MetadataKeywordList.Whitelist}
 			var blacklist = {MetadataKeywordList.Blacklist}
 			var ignorelist = {MetadataKeywordList.Ignorelist}
+			var hidelist = {MetadataKeywordList.Hidelist}
 			var fileSystem =
 			{
 				"appDir": "{Path.Application:FixPath}"

--- a/src/NHxD.Frontend.Winforms/assets/templates/gallery-tooltip.html
+++ b/src/NHxD.Frontend.Winforms/assets/templates/gallery-tooltip.html
@@ -22,11 +22,12 @@
 			}
 		</style>
 		<script type="text/javascript">
-		    var metadata = {Metadata}
-		    var whitelist = {MetadataKeywordList.Whitelist}
-		    var blacklist = {MetadataKeywordList.Blacklist}
-		    var ignorelist = {MetadataKeywordList.Ignorelist}
-		    var uploadDate = metadata.upload_date
+			var metadata = {Metadata}
+			var whitelist = {MetadataKeywordList.Whitelist}
+			var blacklist = {MetadataKeywordList.Blacklist}
+			var ignorelist = {MetadataKeywordList.Ignorelist}
+			var hidelist = {MetadataKeywordList.Hidelist}
+			var uploadDate = metadata.upload_date
 
 			function markCoverAsLoaded(img)
 			{

--- a/src/NHxD.Frontend.Winforms/assets/templates/library-covergrid.html
+++ b/src/NHxD.Frontend.Winforms/assets/templates/library-covergrid.html
@@ -19,6 +19,7 @@
 			var whitelist = {MetadataKeywordList.Whitelist}
 			var blacklist = {MetadataKeywordList.Blacklist}
 			var ignorelist = {MetadataKeywordList.Ignorelist}
+			var hidelist = {MetadataKeywordList.Hidelist}
 			var search =
 			{
 				"page_index": {Search.PageIndex},

--- a/src/NHxD.Frontend.Winforms/assets/templates/search-covergrid.html
+++ b/src/NHxD.Frontend.Winforms/assets/templates/search-covergrid.html
@@ -18,6 +18,7 @@
 			var whitelist = {MetadataKeywordList.Whitelist}
 			var blacklist = {MetadataKeywordList.Blacklist}
 			var ignorelist = {MetadataKeywordList.Ignorelist}
+			var hidelist = {MetadataKeywordList.Hidelist}
 			var search = {
 				"page_index": {Search.PageIndex},
 				"tag_id": {Search.TagId},

--- a/src/NHxD/LibraryModel.cs
+++ b/src/NHxD/LibraryModel.cs
@@ -20,6 +20,7 @@ namespace NHxD
 		private readonly FileSystemWatcher fileSystemWatcher;
 		private readonly Queue<LibraryEvent> events;
 
+		private ISearchProgressArg searchProgressArg;
 		private int pageIndex = 1;
 
 		public BindingList<string> Filters => filters;
@@ -39,10 +40,24 @@ namespace NHxD
 			}
 		}
 
+		public ISearchProgressArg SearchProgressArg
+		{
+			get
+			{
+				return searchProgressArg;
+			}
+			set
+			{
+				searchProgressArg = value;
+				OnSearchProgressArgChanged();
+			}
+		}
+
 		public ILibraryPollingTimer Timer { get; }
 
 		public event EventHandler FiltersChanged = delegate { };
 		public event EventHandler PageIndexChanged = delegate { };
+		public event EventHandler SearchProgressArgChanged = delegate { };
 		public event LibraryEventHandler Poll = delegate { };
 
 		public LibraryModel(string path, ILibraryPollingTimer timer)
@@ -131,6 +146,11 @@ namespace NHxD
 		protected virtual void OnPageIndexChanged()
 		{
 			PageIndexChanged.Invoke(this, EventArgs.Empty);
+		}
+
+		protected virtual void OnSearchProgressArgChanged()
+		{
+			SearchProgressArgChanged.Invoke(this, EventArgs.Empty);
 		}
 
 		public void EnablePolling()

--- a/src/NHxD/Properties/AssemblyInfo.cs
+++ b/src/NHxD/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.2")]
 
 [assembly: CLSCompliant(true)]
 

--- a/src/NHxD/SearchModel.cs
+++ b/src/NHxD/SearchModel.cs
@@ -52,7 +52,8 @@ namespace NHxD.Frontend.Winforms
 			}
 			set
 			{
-				searchProgressArg = value; OnSearchProgressArgChanged();
+				searchProgressArg = value;
+				OnSearchProgressArgChanged();
 			}
 		}
 


### PR DESCRIPTION
Current implementation is to mutate and replace the original search result.

A better and simpler approach should be to simply skip hidden items in the cover downloader job and hide items in the JS scripts.